### PR TITLE
Update to Proptypes package instead of Proptypes imported from react 

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
     "jest-expo": "~18.0.0",
+    "prop-types": "^15.5.10",
     "react-native-scripts": "0.0.50",
     "react-test-renderer": "16.0.0-alpha.12"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,8 @@
 
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
 import { TextInput } from 'react-native'
 import { createFilter } from './util'
+import PropTypes from 'prop-types';
 
 export default class SearchInput extends Component{
 


### PR DESCRIPTION
React recently removed PropTypes from their core library as of React 15.5.