### PR TITLE
Wildcard peerDependency for react-native

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "author": "mjsolidarios <markjoseph.solidarios@gmail.com> <https://github.com/mjsolidarios>",
   "license": "MIT",
   "peerDependencies": {
-    "react-native": "^0.41.2"
+    "react-native": ">= 0.41.2"
   },
   "dependencies": {
     "fuse.js": "^3.0.5",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "author": "mjsolidarios <markjoseph.solidarios@gmail.com> <https://github.com/mjsolidarios>",
   "license": "MIT",
   "peerDependencies": {
-    "react-native": "0.41.2"
+    "react-native": "^0.41.2"
   },
   "dependencies": {
     "fuse.js": "^3.0.5",


### PR DESCRIPTION
My development team is currently using react-native 0.46.x.  We use `npm shrinkwrap` to lock down our packages amongst developers.  Including react-native-search-filter in our project means we're no longer able to run `npm shrinkwrap` unless we were to downgrade to react-native 0.41.2 (see [this issue](https://github.com/npm/npm/issues/5135) on npm's repo).

Adding this version range resolves our `npm shrinkwrap` issue.