### PR TITLE
Allows to remove diacritics (ã, ó, ê, etc ... )  from terms/strings before searching.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react-native": ">= 0.41.2"
   },
   "dependencies": {
+    "diacritics": "^1.3.0",
     "fuse.js": "^3.0.5",
     "react-native-search-filter": "^0.1.1"
   }

--- a/src/util.js
+++ b/src/util.js
@@ -1,4 +1,5 @@
 import Fuse from 'fuse.js'
+import {remove as removeDiacritics} from 'diacritics'
 
 function flatten (array) {
   return array.reduce((flat, toFlatten) => (
@@ -39,8 +40,11 @@ export function getValuesForKey (key, item) {
   return results.filter(r => typeof r === 'string' || typeof r === 'number')
 }
 
-export function searchStrings (strings, term, {caseSensitive, fuzzy, sortResults} = {}) {
-  strings = strings.map(e => e.toString())
+export function searchStrings (strings, term, {caseSensitive, fuzzy, sortResults, normalize} = {}) {
+  strings = strings.map(e => {
+    const str = e.toString()
+    return normalize && removeDiacritics(str) || str
+  })
 
   try {
     if (fuzzy) {
@@ -77,6 +81,10 @@ export function createFilter (term, keys, options = {}) {
 
     if (!options.caseSensitive) {
       term = term.toLowerCase()
+    }
+
+    if (options.normalize) {
+      term = removeDiacritics(term)
     }
 
     const terms = term.split(' ')

--- a/yarn.lock
+++ b/yarn.lock
@@ -1286,6 +1286,10 @@ detect-indent@^4.0.0:
   dependencies:
     repeating "^2.0.0"
 
+diacritics@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/diacritics/-/diacritics-1.3.0.tgz#3efa87323ebb863e6696cebb0082d48ff3d6f7a1"
+
 diff@^3.0.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c"


### PR DESCRIPTION
Allows to remove diacritics (ã, ó, etc ... )  from terms/strings before searching.

Currently, if I search for `Joa`in the list `["João", "Joana", "José"]` I only get `Joana` back. Conversely, if I search for `Joã` I get only `João` from the list.

With these changes, if we pass `normalize=true` to the options on createFilter, we would get `João, Joana` from the list, which is the expected behaviour in search fields for languages that has diacritics.